### PR TITLE
Update Rundiv.js

### DIFF
--- a/Rundiv.js
+++ b/Rundiv.js
@@ -162,7 +162,10 @@ function Rundiv(container, options) {
   }
 
   function handleNav(page,to){
-
+    if (length == 2) {
+      page = page % 2;
+      to = to % 2;
+    }
     options.listelem.children[page].className = "";
     options.listelem.children[to].className = "active";
 


### PR DESCRIPTION
fix nav index error in 2 slides situation .

detail:
when there are only 2 slides, designer add 2 more slides(don't know why), and the nav index can be more then 1 which can cause index error.
